### PR TITLE
Add case insensitive search for trapdoor

### DIFF
--- a/qa/trapdoor.py
+++ b/qa/trapdoor.py
@@ -317,6 +317,15 @@ class TrapdoorProgram(object):
                 bisect.insort(l, message)
         # 2) Loop over all files and collect some source context for each message
         for filename, file_messages in mdict.iteritems():
+            # case insensitive search for filename
+            try:
+                dir_name = os.path.dirname(filename)
+                filename, = [os.path.join(dir_name, i) for i in os.listdir(dir_name)
+                             if i.lower() == os.path.basename(filename).lower()]
+            except ValueError:
+                raise IOError('Cannot find exactly one file that is a case insensitive '
+                              'match for {0}'.format(filename))
+
             with open(filename) as source_file:
                 lines = source_file.readlines()
                 for message in file_messages:


### PR DESCRIPTION
Because pydocstyle automatically turns all the filenames into lowercase
(resulting in trapdoor._add_context not being able to find the file).
Adding case insensitive search is easier than modifying pydocstyle.

Fixes #1