### PR TITLE
Adding flexibility to trapdoor configurations

### DIFF
--- a/qa/trapdoor.cfg.sample
+++ b/qa/trapdoor.cfg.sample
@@ -24,7 +24,13 @@
                                                     "ignore": ""}
                                              }
                                    },
-    "trapdoor_pylint_config": {},
+    "trapdoor_pylint_config": {"default_rc":  "pylintrc",
+                               "custom": {"1": {"rc": "",
+                                                "files": []
+                                               }
+
+                                         }
+                              }
     "trapdoor_cppcheck_config": {},
     "trapdoor_cpplint_config": {},
     "trapdoor_doxygen_config": {}

--- a/qa/trapdoor.cfg.sample
+++ b/qa/trapdoor.cfg.sample
@@ -13,7 +13,12 @@
     "trapdoor_namespace_config": {},
     "trapdoor_coverage_config": {},
     "trapdoor_pycodestyle_config": {},
-    "trapdoor_pydocstyle_config": {},
+    "trapdoor_pydocstyle_config": {"default_match": ".*\\.py",
+                                   "default_ignore": "D100,D101,D102,D103,D104,D105",
+                                   "custom": {"1": {"match": "",
+                                                    "ignore": ""}
+                                             }
+                                   },
     "trapdoor_pylint_config": {},
     "trapdoor_cppcheck_config": {},
     "trapdoor_cpplint_config": {},

--- a/qa/trapdoor.cfg.sample
+++ b/qa/trapdoor.cfg.sample
@@ -9,5 +9,13 @@
     "cpp_exclude": ["*_inc.cpp", "cext.cpp"],
     "doxygen_root": "doc",
     "doxygen_conf": "doxygen.conf",
-    "doxygen_warnings": "doxygen_warnings.log"
+    "doxygen_warnings": "doxygen_warnings.log",
+    "trapdoor_namespace_config": {},
+    "trapdoor_coverage_config": {},
+    "trapdoor_pycodestyle_config": {},
+    "trapdoor_pydocstyle_config": {},
+    "trapdoor_pylint_config": {},
+    "trapdoor_cppcheck_config": {},
+    "trapdoor_cpplint_config": {},
+    "trapdoor_doxygen_config": {}
 }

--- a/qa/trapdoor.cfg.sample
+++ b/qa/trapdoor.cfg.sample
@@ -12,7 +12,12 @@
     "doxygen_warnings": "doxygen_warnings.log",
     "trapdoor_namespace_config": {},
     "trapdoor_coverage_config": {},
-    "trapdoor_pycodestyle_config": {},
+    "trapdoor_pycodestyle_config": {"default_config_file": "pycodestyle.ini",
+                                    "custom": {"1": {"config_file": "",
+                                                     "directories": []
+                                                    }
+                                              }
+                                   },
     "trapdoor_pydocstyle_config": {"default_match": ".*\\.py",
                                    "default_ignore": "D100,D101,D102,D103,D104,D105",
                                    "custom": {"1": {"match": "",

--- a/qa/trapdoor.py
+++ b/qa/trapdoor.py
@@ -268,6 +268,13 @@ class TrapdoorProgram(object):
             custom_config = 'trapdoor_{0}_config'.format(self.name)
             if custom_config in config:
                 config.update(config[custom_config])
+            # cleanup
+            del config['trapdoor_import_config']
+            del config['trapdoor_namespace_config']
+            del config['trapdoor_coverage_config']
+            del config['trapdoor_pycodestyle_config']
+            del config['trapdoor_pydocstyle_config']
+            del config['trapdoor_pylint_config']
 
         counter, messages = self.get_stats(config, args)
         print 'NUMBER OF MESSAGES :', len(messages)

--- a/qa/trapdoor.py
+++ b/qa/trapdoor.py
@@ -264,6 +264,11 @@ class TrapdoorProgram(object):
         start_time = time.time()
         with open(self.trapdoor_config_file, 'r') as f:
             config = json.load(f)
+            # overwrite default configuration with custom configuration
+            custom_config = 'trapdoor_{0}_config'.format(self.name)
+            if custom_config in config:
+                config.update(config[custom_config])
+
         counter, messages = self.get_stats(config, args)
         print 'NUMBER OF MESSAGES :', len(messages)
         print 'ADDING SOURCE ...'

--- a/qa/trapdoor_pycodestyle.py
+++ b/qa/trapdoor_pycodestyle.py
@@ -40,7 +40,6 @@ class PyCodeStyleTrapdoorProgram(TrapdoorProgram):
     def __init__(self):
         """Initialize the PyCodeStyleTrapdoorProgram."""
         TrapdoorProgram.__init__(self, 'pycodestyle')
-        self.config_file = os.path.join(self.qaworkdir, 'pycodestyle.ini')
 
     def prepare(self):
         """Make some preparations in feature branch for running pycodestyle.
@@ -48,8 +47,6 @@ class PyCodeStyleTrapdoorProgram(TrapdoorProgram):
         This includes a copy of tools/qa/pycodestyle to QAWORKDIR.
         """
         TrapdoorProgram.prepare(self)
-        qatooldir = os.path.dirname(os.path.abspath(__file__))
-        shutil.copy(os.path.join(qatooldir, os.path.basename(self.config_file)), self.config_file)
 
     def get_stats(self, config, args):
         """Run tests using pycodestyle.
@@ -71,10 +68,35 @@ class PyCodeStyleTrapdoorProgram(TrapdoorProgram):
         # Get version
         print 'USING PYCODESTYLE  :', pycodestyle.__version__
 
-        # Call pycodestyle
+        qatooldir = os.path.dirname(os.path.abspath(__file__))
+        exclude_directories = []
+        # run pycode test on each directories
+        for custom_config in config['custom'].values():
+            # copy over configfile
+            config_file = os.path.join(self.qaworkdir, custom_config['config_file'])
+            # FIXME: not too sure if this should be in prepare
+            shutil.copy(os.path.join(qatooldir, os.path.basename(config_file)), config_file)
+            
+            # Call pycodestyle with custom config file
+            styleguide = pycodestyle.StyleGuide(reporter=CompleteReport, config_file=config_file)
+            styleguide.options.exclude.extend(config['py_exclude'])
+            print 'EXCLUDED FILES     :', styleguide.options.exclude
+            print 'IGNORED MESSAGES   :', styleguide.options.ignore
+            print 'MAX LINE LENGTH    :', styleguide.options.max_line_length
+            for py_directory in custom_config['directories']:
+                print 'RUNNING            : pycodestyle %s (through Python API)' % py_directory
+                styleguide.input_dir(py_directory)
+            exclude_directories += [os.path.abspath(i) for i in custom_config['directories']]
+        # copy over configfile
+        default_config_file = os.path.join(self.qaworkdir, config['default_config_file'])
+        # FIXME: not too sure if this should be in prepare
+        shutil.copy(os.path.join(qatooldir, os.path.basename(default_config_file)),
+                    default_config_file)
+        # Call pycodestyle with default config file (for files that have not been tested yet)
         styleguide = pycodestyle.StyleGuide(reporter=CompleteReport,
-                                            config_file=self.config_file)
+                                            config_file=default_config_file)
         styleguide.options.exclude.extend(config['py_exclude'])
+        styleguide.options.exclude.extend(exclude_directories)
         print 'EXCLUDED FILES     :', styleguide.options.exclude
         print 'IGNORED MESSAGES   :', styleguide.options.ignore
         print 'MAX LINE LENGTH    :', styleguide.options.max_line_length

--- a/qa/trapdoor_pylint.py
+++ b/qa/trapdoor_pylint.py
@@ -42,7 +42,6 @@ class PylintTrapdoorProgram(TrapdoorProgram):
     def __init__(self):
         """Initialize a PylintTrapdoorProgram instance."""
         TrapdoorProgram.__init__(self, 'pylint')
-        self.rcfile = os.path.join(self.qaworkdir, 'pylintrc')
 
     def prepare(self):
         """Make some preparations in feature branch for running pylint.
@@ -50,8 +49,6 @@ class PylintTrapdoorProgram(TrapdoorProgram):
         This includes a copy of tools/qa/pylintrc to QAWORKDIR.
         """
         TrapdoorProgram.prepare(self)
-        qatooldir = os.path.dirname(os.path.abspath(__file__))
-        shutil.copy(os.path.join(qatooldir, 'pylintrc'), self.rcfile)
 
     def get_stats(self, config, args):
         """Run tests using Pylint.
@@ -70,22 +67,58 @@ class PylintTrapdoorProgram(TrapdoorProgram):
         messages : Set([]) of strings
                    All errors encountered in the current branch.
         """
+        # get default rcfile
+        qatooldir = os.path.dirname(os.path.abspath(__file__))
+        default_rc_file = os.path.join(self.qaworkdir, config['default_rc'])
+        # FIXME: not too sure if this should be in prepare
+        shutil.copy(os.path.join(qatooldir, os.path.basename(default_rc_file)), default_rc_file)
+
         # get Pylint version
-        command = ['pylint', '--version', '--rcfile=%s' % self.rcfile]
+        command = ['pylint', '--version', '--rcfile={0}'.format(default_rc_file)]
         version_info = ''.join(run_command(command, verbose=False)[0].split('\n')[:2])
         print 'USING              :', version_info
 
         # Collect python files not present in packages
         py_extra = get_source_filenames(config, 'py', unpackaged_only=True)
 
+        output = ''
+        exclude_files = []
+        # run pylint test using each configuration
+        for custom_config in config['custom'].values():
+            rc_file = os.path.join(self.qaworkdir, custom_config['rc'])
+            shutil.copy(os.path.join(qatooldir, os.path.basename(rc_file)), rc_file)
+
+            # get list of files in the given directories/files
+            py_files = []
+            for custom_file in custom_config['files']:
+                if custom_file in config['py_packages']:
+                    py_files.append(custom_file)
+                    continue
+                elif os.path.isfile(custom_file):
+                    py_files.append(custom_file)
+                for dirpath, _dirnames, filenames in os.walk(custom_file):
+                    for filename in filenames:
+                        if os.path.splitext(filename)[1] == '.py':
+                            py_files.append(os.path.join(dirpath, filename))
+            # call Pylint
+            output += run_command(['pylint'] +
+                                  py_files +
+                                  ['--rcfile={0}'.format(rc_file),
+                                   '--ignore={0}'.format(','.join(config['py_exclude'])),
+                                   '-j 2', ],
+                                  has_failed=has_failed)[0]
+            # exclude directories/files
+            exclude_files.extend(py_files)
+        # remove excluded files
+        py_files = [i for i in config['py_packages'] + py_extra if i not in exclude_files]
         # call Pylint
-        command = ['pylint'] + config['py_packages'] \
-                  + py_extra \
-                  + ['--rcfile=%s' % self.rcfile,
-                     '--ignore=%s' % (
-                         ','.join(config['py_exclude'])),
-                     '-j 2', ]
-        output = run_command(command, has_failed=has_failed)[0]
+        output += run_command(['pylint'] +
+                              py_files +
+                              ['--rcfile={0}'.format(default_rc_file),
+                               '--ignore={0}'.format(','.join(config['py_exclude'] +
+                                                              exclude_files)),
+                               '-j 2', ],
+                              has_failed=has_failed)[0]
 
         # parse the output of Pylint into standard return values
         lines = output.split('\n')[:-1]


### PR DESCRIPTION
Make separate configuration for each trapdoor instead of sharing options. If appropriate keys are specified, they overwrite the existing key/value. Otherwise, the "default" values are used.