### PR TITLE
Chemtools update

### DIFF
--- a/codecleaner.py
+++ b/codecleaner.py
@@ -25,13 +25,16 @@ import sys
 
 
 def clean_code(fn):
-    """Return the clean version of a file in which trailing whitespaces on each line are removed,
-       tabs are replaced by four spaces, and empty lines at the end of the file are discarded.
+    """Return the clean version of a file.
 
-       *** Arguments ***
+    Trailing whitespaces are removed.
+    Tabs are replaced with four spaces
+    Empty lines at the end of the file are discarded
 
-       fn
-           The file to be cleaned.
+    Parameters
+    ----------
+    fn
+       The file to be cleaned.
     """
     print 'Cleaning'.upper(), fn
 

--- a/qa/pycodestyle_examples.ini
+++ b/qa/pycodestyle_examples.ini
@@ -1,0 +1,4 @@
+[pep8]
+exclude = .svn, CVS, .bzr, .hg, .git, __pycache__
+ignore = E121,E123,E126,E127,E128,E226,E241,W503,E402
+max-line-length = 100

--- a/qa/pycodestyle_test.ini
+++ b/qa/pycodestyle_test.ini
@@ -1,0 +1,4 @@
+[pep8]
+exclude = .svn, CVS, .bzr, .hg, .git, __pycache__
+ignore = E121,E123,E126,E127,E128,E226,E241,W503,E731,E201
+max-line-length = 120

--- a/qa/pylintrc_example
+++ b/qa/pylintrc_example
@@ -1,0 +1,364 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=~/.config/pylintrc
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=yes
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=I0020,I0021,W0704,E0611,E1101,C0103,W0212,I0011,R0201,C0411,W0613,W0621,E1136,W0221,W0223,C0413
+#disable=all
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=parseable
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template='{msg_id} {symbol} {path}:{line},{column} {msg}'
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__)|(test_.*)
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_.*|_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=20
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=50
+
+# Maximum number of return / yield for function / method body
+max-returns=10
+
+# Maximum number of branch for function / method body
+max-branches=50
+
+# Maximum number of statements in function / method body
+max-statements=250
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=50
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/qa/pylintrc_init
+++ b/qa/pylintrc_init
@@ -1,0 +1,364 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=~/.config/pylintrc
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=yes
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=I0020,I0021,W0704,E0611,E1101,C0103,W0212,I0011,R0201,C0411,W0613,W0621,E1136,W0221,W0223,W0401
+#disable=all
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=parseable
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template='{msg_id} {symbol} {path}:{line},{column} {msg}'
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__)|(test_.*)
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_.*|_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=20
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=50
+
+# Maximum number of return / yield for function / method body
+max-returns=10
+
+# Maximum number of branch for function / method body
+max-branches=50
+
+# Maximum number of statements in function / method body
+max-statements=250
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=50
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/qa/pylintrc_test
+++ b/qa/pylintrc_test
@@ -1,0 +1,364 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=~/.config/pylintrc
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=yes
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=I0020,I0021,W0704,E0611,E1101,C0103,W0212,I0011,R0201,C0411,W0613,W0621,E1136,W0221,W0223,C0326,C0330,C0102
+#disable=all
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=parseable
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template='{msg_id} {symbol} {path}:{line},{column} {msg}'
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__)|(test_.*)
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_.*|_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=20
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=50
+
+# Maximum number of return / yield for function / method body
+max-returns=10
+
+# Maximum number of branch for function / method body
+max-branches=50
+
+# Maximum number of statements in function / method body
+max-statements=250
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=50
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/qa/trapdoor.cfg
+++ b/qa/trapdoor.cfg
@@ -6,15 +6,15 @@
     "py_invalid_names": ["np", "numpy", "m", "math", "scipy", "sp", "matplotlib",
                          "pyplot", "plt", "pt", "h5py", "h5",
                          "contextlib", "abc", "horton"],
-    "cpp_directories": ["chemtools"],
-    "cpp_exclude": ["*_inc.cpp", "cext.cpp"],
-    "doxygen_root": "doc",
-    "doxygen_conf": "doxygen.conf",
-    "doxygen_warnings": "doxygen_warnings.log",
     "trapdoor_import_config": {"py_directories": ["chemtools", "tools", "scripts"]},
     "trapdoor_namespace_config": {},
     "trapdoor_coverage_config": {},
     "trapdoor_pycodestyle_config": {},
-    "trapdoor_pydocstyle_config": {},
+    "trapdoor_pydocstyle_config": {"default_match": ".*\\.py",
+                                   "default_ignore": "D100,D101,D102,D103,D104,D105",
+                                   "custom": {"1": {"match": "ex.*\\.py",
+                                                    "ignore": "D100,D101,D102,D103,D104,D105,D205,D400"}
+                                             }
+                                   },
     "trapdoor_pylint_config": {}
 }

--- a/qa/trapdoor.cfg
+++ b/qa/trapdoor.cfg
@@ -10,5 +10,11 @@
     "cpp_exclude": ["*_inc.cpp", "cext.cpp"],
     "doxygen_root": "doc",
     "doxygen_conf": "doxygen.conf",
-    "doxygen_warnings": "doxygen_warnings.log"
+    "doxygen_warnings": "doxygen_warnings.log",
+    "trapdoor_import_config": {"py_directories": ["chemtools", "tools", "scripts"]},
+    "trapdoor_namespace_config": {},
+    "trapdoor_coverage_config": {},
+    "trapdoor_pycodestyle_config": {},
+    "trapdoor_pydocstyle_config": {},
+    "trapdoor_pylint_config": {}
 }

--- a/qa/trapdoor.cfg
+++ b/qa/trapdoor.cfg
@@ -23,5 +23,11 @@
                                                     "ignore": "D100,D101,D102,D103,D104,D105,D205,D400"}
                                              }
                                    },
-    "trapdoor_pylint_config": {}
+    "trapdoor_pylint_config": {"default_rc":  "pylintrc",
+                               "custom": {"1": {"rc": "pylintrc_example",
+                                                "custom_file": ["examples"]
+                                               }
+
+                                         }
+                              }
 }

--- a/qa/trapdoor.cfg
+++ b/qa/trapdoor.cfg
@@ -9,7 +9,14 @@
     "trapdoor_import_config": {"py_directories": ["chemtools", "tools", "scripts"]},
     "trapdoor_namespace_config": {},
     "trapdoor_coverage_config": {},
-    "trapdoor_pycodestyle_config": {},
+    "trapdoor_pycodestyle_config": {"default_config_file": "pycodestyle.ini",
+                                    "custom": {"1": {"config_file": "pycodestyle_test.ini",
+                                                     "directory": ["chemtools/analysis/test",
+                                                                   "chemtools/toolbox/test",
+                                                                   "chemtools/utils/test"]
+                                                    }
+                                              }
+                                   },
     "trapdoor_pydocstyle_config": {"default_match": ".*\\.py",
                                    "default_ignore": "D100,D101,D102,D103,D104,D105",
                                    "custom": {"1": {"match": "ex.*\\.py",

--- a/qa/trapdoor.cfg
+++ b/qa/trapdoor.cfg
@@ -24,7 +24,15 @@
                                              }
                                    },
     "trapdoor_pylint_config": {"default_rc":  "pylintrc",
-                               "custom": {"1": {"rc": "pylintrc_example",
+                               "custom": {"1": {"rc": "pylintrc_init",
+                                                "custom_file": ["chemtools/__init__.py",
+                                                                "chemtools/analysis/__init__.py",
+                                                                "chemtools/toolbox/__init__.py",
+                                                                "chemtools/utils/__init__.py",
+                                                                "tools/__init__.py"]
+
+                                               },
+                                          "2": {"rc": "pylintrc_example",
                                                 "custom_file": ["examples"]
                                                }
 

--- a/qa/trapdoor.cfg
+++ b/qa/trapdoor.cfg
@@ -6,7 +6,7 @@
     "py_invalid_names": ["np", "numpy", "m", "math", "scipy", "sp", "matplotlib",
                          "pyplot", "plt", "pt", "h5py", "h5",
                          "contextlib", "abc", "horton"],
-    "trapdoor_import_config": {"py_directories": ["chemtools", "tools", "scripts"]},
+    "trapdoor_import_config": {"py_directories": ["chemtools", "tools"]},
     "trapdoor_namespace_config": {},
     "trapdoor_coverage_config": {},
     "trapdoor_pycodestyle_config": {"default_config_file": "pycodestyle.ini",
@@ -14,6 +14,9 @@
                                                      "directory": ["chemtools/analysis/test",
                                                                    "chemtools/toolbox/test",
                                                                    "chemtools/utils/test"]
+                                                    },
+                                               "2": {"config_file": "pycodestyle_examples.ini",
+                                                     "directory": ["examples"]
                                                     }
                                               }
                                    },
@@ -34,8 +37,12 @@
                                                },
                                           "2": {"rc": "pylintrc_example",
                                                 "custom_file": ["examples"]
+                                               },
+                                          "3": {"rc": "pylintrc_test",
+                                                "custom_file": ["chemtools/analysis/test",
+                                                                "chemtools/toolbox/test",
+                                                                "chemtools/utils/test"]
                                                }
-
                                          }
                               }
 }

--- a/qa/trapdoor.py
+++ b/qa/trapdoor.py
@@ -268,6 +268,13 @@ class TrapdoorProgram(object):
             custom_config = 'trapdoor_{0}_config'.format(self.name)
             if custom_config in config:
                 config.update(config[custom_config])
+            # cleanup
+            del config['trapdoor_import_config']
+            del config['trapdoor_namespace_config']
+            del config['trapdoor_coverage_config']
+            del config['trapdoor_pycodestyle_config']
+            del config['trapdoor_pydocstyle_config']
+            del config['trapdoor_pylint_config']
 
         counter, messages = self.get_stats(config, args)
         _print_messages('MESSAGES :', messages, pattern=None)

--- a/qa/trapdoor.py
+++ b/qa/trapdoor.py
@@ -264,6 +264,11 @@ class TrapdoorProgram(object):
         start_time = time.time()
         with open(self.trapdoor_config_file, 'r') as f:
             config = json.load(f)
+            # overwrite default configuration with custom configuration
+            custom_config = 'trapdoor_{0}_config'.format(self.name)
+            if custom_config in config:
+                config.update(config[custom_config])
+
         counter, messages = self.get_stats(config, args)
         _print_messages('MESSAGES :', messages, pattern=None)
         print 'NUMBER OF MESSAGES :', len(messages)

--- a/qa/trapdoor_pydocstyle.py
+++ b/qa/trapdoor_pydocstyle.py
@@ -66,14 +66,27 @@ class PyDocStyleTrapdoorProgram(TrapdoorProgram):
         version = run_command(command, verbose=False)[0].strip()
         print 'USING              : pydocstyle', version
 
-        # Call pydocstyle in the directories containing Python code. All files will be
-        # checked, including test files. Missing docstrings are ignored because they are
-        # detected by PyLint in a better way.
-        command = ['pydocstyle', '--match=.*\\.py',
-                   '--add-ignore=D100,D101,D102,D103,D104,D105'] + \
-                  config['py_packages'] + \
-                  get_source_filenames(config, 'py', unpackaged_only=True)
-        output = run_command(command, has_failed=has_failed)[1]
+        default_match = '({0})'.format(config['default_match'])
+        output = ''
+        for custom_config in config['custom'].values():
+            match = custom_config['match']
+            ignore = custom_config['ignore']
+            default_match = '(?!{0}){1}'.format(match, default_match)
+            # Call pydocstyle in the directories containing Python code. All files will be
+            # checked, including test files. Missing docstrings are ignored because they are
+            # detected by PyLint in a better way.
+            output += run_command(['pydocstyle',
+                                   '--match={0}'.format(match),
+                                   '--add-ignore={0}'.format(ignore)] +
+                                  config['py_packages'] +
+                                  get_source_filenames(config, 'py', unpackaged_only=True),
+                                  has_failed=has_failed)[1]
+        output += run_command(['pydocstyle',
+                               '--match={0}'.format(default_match),
+                               '--add-ignore={0}'.format(config['default_ignore'])] +
+                              config['py_packages'] +
+                              get_source_filenames(config, 'py', unpackaged_only=True),
+                              has_failed=has_failed)[1]
 
         # Parse the standard output of pydocstyle
         counter = Counter()

--- a/qa/trapdoor_pylint.py
+++ b/qa/trapdoor_pylint.py
@@ -80,6 +80,7 @@ class PylintTrapdoorProgram(TrapdoorProgram):
 
         # Collect python files (pylint ignore is quite bad.. need to ignore manually)
         py_extra = get_source_filenames(config, 'py', unpackaged_only=True)
+
         def get_filenames(file_or_dir, exclude=tuple()):
             """Recursively finds all of the files within the given file or directory.
 

--- a/qa/trapdoor_pylint.py
+++ b/qa/trapdoor_pylint.py
@@ -78,8 +78,39 @@ class PylintTrapdoorProgram(TrapdoorProgram):
         version_info = ''.join(run_command(command, verbose=False)[0].split('\n')[:2])
         print 'USING              :', version_info
 
-        # Collect python files not present in packages
+        # Collect python files (pylint ignore is quite bad.. need to ignore manually)
         py_extra = get_source_filenames(config, 'py', unpackaged_only=True)
+        def get_filenames(file_or_dir, exclude=tuple()):
+            """Recursively finds all of the files within the given file or directory.
+
+            Parameters
+            ----------
+            file_or_dir : str
+                File or directory
+            exclude : tuple
+                Files or directories to ignore
+
+            Returns
+            -------
+            list of files in absolute path
+            """
+            output = []
+            if os.path.isfile(file_or_dir) and file_or_dir not in exclude:
+                output.append(file_or_dir)
+            elif os.path.isdir(file_or_dir):
+                for dirpath, _dirnames, filenames in os.walk(file_or_dir):
+                    # check if directory is allowed
+                    if any(os.path.samefile(dirpath, i) for i in exclude):
+                        continue
+                    for filename in filenames:
+                        # check if filename is allowed
+                        if (os.path.splitext(filename)[1] != '.py' or
+                                filename in exclude or
+                                any(os.path.samefile(os.path.join(dirpath, filename), i)
+                                    for i in exclude)):
+                            continue
+                        output.append(os.path.join(dirpath, filename))
+            return output
 
         output = ''
         exclude_files = []
@@ -87,34 +118,27 @@ class PylintTrapdoorProgram(TrapdoorProgram):
             rc_file = os.path.join(self.qaworkdir, custom_config['rc'])
             shutil.copy(os.path.join(qatooldir, os.path.basename(rc_file)), rc_file)
 
+            # collect files
             py_files = []
             for custom_file in custom_config['custom_file']:
-                if custom_file in config['py_packages']:
-                    py_files.append(custom_file)
-                    continue
-                elif os.path.isfile(custom_file):
-                    py_files.append(custom_file)
-                for dirpath, _dirnames, filenames in os.walk(custom_file):
-                    for filename in filenames:
-                        if os.path.splitext(filename)[1] == '.py':
-                            py_files.append(os.path.join(dirpath, filename))
+                py_files.extend(get_filenames(custom_file))
+
             # call Pylint
             output += run_command(['pylint'] +
                                   py_files +
                                   ['--rcfile={0}'.format(rc_file),
-                                   '--ignore={0}'.format(','.join(config['py_exclude'])),
                                    '-j 2', ],
                                   has_failed=has_failed)[0]
             # exclude directories/files
             exclude_files.extend(py_files)
-        # remove excluded files
-        py_files = [i for i in config['py_packages'] + py_extra if i not in exclude_files]
+        # get files that have not been run
+        py_files = []
+        for py_file in config['py_packages'] + py_extra:
+            py_files.extend(get_filenames(py_file, exclude=exclude_files + config['py_exclude']))
         # call Pylint
         output += run_command(['pylint'] +
                               py_files +
                               ['--rcfile={0}'.format(default_rc_file),
-                               '--ignore={0}'.format(','.join(config['py_exclude'] +
-                                                              exclude_files)),
                                '-j 2', ],
                               has_failed=has_failed)[0]
 


### PR DESCRIPTION
Each trapdoor can now have different configurations for each set of directories or files. The default "variables" such as `py_packages`, `py_directories`, `py_test_files` `py_exclude` and so on can be overwritten for each trapdoor as well.

Custom configurations were created for the `trapdoor_import.py`, `trapdoor_pydocstyle.py`, `trapdoor_pycodestyle.py`, `trapdoor_pylint.py` have been added for chemtools.

Several small changes have been made so that the QA code meets its own standards.