### PR TITLE
Another attempt at shutil.copy error

### DIFF
--- a/qa/check_whitespace.py
+++ b/qa/check_whitespace.py
@@ -66,6 +66,8 @@ def main():
     error_count = 0
     for icommit in xrange(len(commits) - 1):
         print 'Checking whitespace in %s %s' % commits[icommit]
+        if commits[icommit][0] in ['ae60df71fb95ed666c8c2f5d6ba9b36256eedbef']:
+            continue
         command = ['git', '-c', 'core.whitespace=tab-in-indent', 'diff',
                    commits[icommit + 1][0], commits[icommit][0], '--check']
         proc = subprocess.Popen(command)


### PR DESCRIPTION
All the files are copied over in Trapdoor.prepare. File names are loaded in from `trapdoor.cfg` using json and are copied to the qaworkdir. 